### PR TITLE
Fix gemspec and readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.8.7
   - 1.9.3
+  - 2.0.0
   - jruby-18mode
   - jruby-19mode
 script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in test.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 
 
 gem 'rcov', :platform => :mri_18
-gem 'simplecov', :platform => :mri_19
-gem 'simplecov-rcov', :platform => :mri_19
+gem 'simplecov', :platforms => [:mri_19, :mri_20]
+gem 'simplecov-rcov', :platforms => [:mri_19, :mri_20]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pairtree
 
-Ruby implementation of the [Pairtree](https://confluence.ucop.edu/display/Curation/PairTree microservice specification from the California Digital Librar)
+Ruby implementation of the [Pairtree](https://confluence.ucop.edu/display/Curation/PairTree) microservice specification from the California Digital Library.
 
 # Usage
 

--- a/lib/pairtree/identifier.rb
+++ b/lib/pairtree/identifier.rb
@@ -16,19 +16,23 @@ module Pairtree
     # @param [String] id The identifier
     def self.decode id
       input = id.tr('=+,', '/:.').bytes.to_a
-      output = []
+      intermediate = []
       while input.first
         if input.first == 94
           h = []
           input.shift
           h << input.shift
           h << input.shift
-          output << h.pack('c*').hex
+          intermediate << h.pack('c*').hex
         else
-          output << input.shift
+          intermediate << input.shift
         end
       end
-      output.pack('c*').force_encoding('UTF-8')
+      result = intermediate.pack('c*')
+      if result.respond_to? :force_encoding
+        result.force_encoding('UTF-8')
+      end
+      result
     end
 
     ##

--- a/lib/pairtree/identifier.rb
+++ b/lib/pairtree/identifier.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Pairtree
   class Identifier
     ENCODE_REGEX = Regexp.compile("[\"*+,<=>?\\\\^|]|[^\x21-\x7e]", nil)
@@ -14,7 +15,20 @@ module Pairtree
     # Decode special characters within an identifier
     # @param [String] id The identifier
     def self.decode id
-      id.tr('=+,', '/:.').gsub(DECODE_REGEX) { |h| hex2char(h) } 
+      input = id.tr('=+,', '/:.').bytes.to_a
+      output = []
+      while input.first
+        if input.first == 94
+          h = []
+          input.shift
+          h << input.shift
+          h << input.shift
+          output << h.pack('c*').hex
+        else
+          output << input.shift
+        end
+      end
+      output.pack('c*').force_encoding('UTF-8')
     end
 
     ##

--- a/pairtree.gemspec
+++ b/pairtree.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email            = %q{chris@cbeer.info}
   s.files            = `git ls-files`.split("\n")
   s.test_files       = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.extra_rdoc_files = ["LICENSE.txt", "README.textile"]
+  s.extra_rdoc_files = ["LICENSE.txt", "README.md"]
   s.executables      = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths    = ["lib"]
 

--- a/spec/pairtree/pairtree_encoding_spec.rb
+++ b/spec/pairtree/pairtree_encoding_spec.rb
@@ -78,7 +78,7 @@ describe "Pairtree encoding" do
   end
   
   it "should roundtrip French" do
-    roundtrip('Années de Pèlerinage')
+    roundtrip('Années de Pèlerinage', 'Ann^c3^a9es^20de^20P^c3^a8lerinage', 'An/n^/c3/^a/9e/s^/20/de/^2/0P/^c/3^/a8/le/ri/na/ge/Ann^c3^a9es^20de^20P^c3^a8lerinage')
     roundtrip(%{
       Années de Pèlerinage (Years of Pilgrimage) (S.160, S.161,
       S.163) is a set of three suites by Franz Liszt for solo piano. Liszt's

--- a/spec/pairtree/pairtree_obj_spec.rb
+++ b/spec/pairtree/pairtree_obj_spec.rb
@@ -30,7 +30,7 @@ describe "Pairtree::Obj" do
   end
   
   it "should be enumerable" do
-    block_body = mock('block_body')
+    block_body = double('block_body')
     block_body.should_receive(:yielded).with('content.xml')
     @obj.each { |file| block_body.yielded(file) }
   end


### PR DESCRIPTION
A couple of minor fixes:
- The gemspec was invalid, and the Gemfile still used 'http://rubygems.org' as a source.
- The link to the PairTree spec was broken.
- The method Pairtree::Identifier.decode did not roundtrip properly in Ruby 2.0.
